### PR TITLE
Change 'yum' module to 'package'

### DIFF
--- a/tasks/install_odl_via_rpm_path.yml
+++ b/tasks/install_odl_via_rpm_path.yml
@@ -1,5 +1,5 @@
 ---
 - name: Install ODL via RPM path
-  yum:
+  package:
     name={{ rpm_path }}
     state=present

--- a/tasks/install_odl_via_rpm_repo.yml
+++ b/tasks/install_odl_via_rpm_repo.yml
@@ -2,7 +2,7 @@
 - include: add_odl_yum_repo.yml
 
 - name: Install ODL via RPM repo
-  yum:
+  package:
     name=opendaylight
     state=present
     update_cache=yes


### PR DESCRIPTION
This change is needed to make usage of the underlying OS package manager, instead of 'yum' only. Caused unknown module failure on Fedora 23.
Signed-off-by: Patrick Laurin plaurin@inocybe.com
