### PR TITLE
Add .deb support to ansible-opendaylight

### DIFF
--- a/tasks/add_jessie_backports.yml
+++ b/tasks/add_jessie_backports.yml
@@ -1,0 +1,6 @@
+- name: Add jessie-backports
+  apt_repository:
+    repo="deb http://httpredir.debian.org/debian jessie-backports main"
+    state=present
+    filename='jessie-backports'
+    update_cache=yes

--- a/tasks/add_odl_deb_repo.yml
+++ b/tasks/add_odl_deb_repo.yml
@@ -10,9 +10,4 @@
     filename='opendaylight'
     update_cache=yes
 
-- name: Add jessie-backports
-  apt_repository:
-    repo="deb http://httpredir.debian.org/debian jessie-backports main"
-    state=present
-    filename='jessie-backports'
-    update_cache=yes
+- include: add_jessie_backports.yml

--- a/tasks/add_odl_deb_repo.yml
+++ b/tasks/add_odl_deb_repo.yml
@@ -1,0 +1,18 @@
+- name: Add the repository key to apt
+  apt_key:
+    url={{ deb_key }}
+    state=present
+
+- name: Add ODL deb repo
+  apt_repository:
+    repo={{ deb_repo_url }}
+    state=present
+    filename='opendaylight'
+    update_cache=yes
+
+- name: Add jessie-backports
+  apt_repository:
+    repo="deb http://httpredir.debian.org/debian jessie-backports main"
+    state=present
+    filename='jessie-backports'
+    update_cache=yes

--- a/tasks/install_odl.yml
+++ b/tasks/install_odl.yml
@@ -1,5 +1,26 @@
 ---
+- name: Debugging
+  debug: msg="{{ ansible_distribution }} {{ ansible_os_family }} {{ ansible_distribution_version }} {{ ansible_distribution_release }} {{ ansible_distribution_major_version }} {{ ansible_lsb.major_release }}"
+
+- set_fact:
+    os="{{ ansible_distribution }}_{{ ansible_distribution_major_version }}.0"
+  when:
+    ansible_distribution == "Debian"
+- set_fact:
+    os="x{{ ansible_distribution }}_{{ ansible_distribution_version }}"
+  when:
+    ansible_distribution == "Ubuntu"
+
+- include: install_odl_via_deb_repo.yml
+  when:
+    - ansible_os_family == "Debian"
+    - install_method == "deb_repo"
+
 - include: install_odl_via_rpm_repo.yml
-  when: install_method == "rpm_repo"
+  when:
+    - ansible_os_family == "CentOS"
+    - install_method == "rpm_repo"
 - include: install_odl_via_rpm_path.yml
-  when: install_method == "rpm_path"
+  when:
+    - ansible_os_family == "CentOS"
+    - install_method == "rpm_path"

--- a/tasks/install_odl.yml
+++ b/tasks/install_odl.yml
@@ -1,23 +1,47 @@
 ---
+# Check the OS and branch for either RPM or Deb installs
+
+# Docs: 
+# `ansible_os_family` param: Operating System family (Debian/RedHat)
+# `ansible_distribtion` param: Operating system (Debian/Ubuntu/CentOS etc.)
+# `ansible_distribution_version` param: The complete version of the OS
+# `ansible_distribution_major_version` param: The major version of the OS
+
+# The .debs are currently hosted in OpenSUSE Build Service (OBS).
+# In OBS, the name of the .deb repository for Debian contains the OS name
+# in the form Debian_{major_version} (eg: Debian_8.0).
 - set_fact:
     os="{{ ansible_distribution }}_{{ ansible_distribution_major_version }}.0"
   when:
     ansible_distribution == "Debian"
+
+# In OBS, the name of the .deb repository for Ubuntu contains the OS name
+# in the form xUbuntu_{version} (eg: xUbuntu_16.04).
 - set_fact:
     os="x{{ ansible_distribution }}_{{ ansible_distribution_version }}"
   when:
     ansible_distribution == "Ubuntu"
 
+# Install ODL .deb using debian repo
 - include: install_odl_via_deb_repo.yml
   when:
     - ansible_os_family == "Debian"
     - install_method == "deb_repo"
 
+# Install ODL using .deb URL or local path to a .deb file
+- include: install_odl_via_deb_path.yml
+  when:
+    - ansible_os_family == "Debian"
+    - install_method == "deb_path"
+
+# Install ODL using Yum repo config
 - include: install_odl_via_rpm_repo.yml
   when:
-    - ansible_os_family == "CentOS"
+    - ansible_os_family == "RedHat"
     - install_method == "rpm_repo"
+
+# Install ODL using rpm URL or a local path to a rpm file
 - include: install_odl_via_rpm_path.yml
   when:
-    - ansible_os_family == "CentOS"
+    - ansible_os_family == "RedHat"
     - install_method == "rpm_path"

--- a/tasks/install_odl.yml
+++ b/tasks/install_odl.yml
@@ -1,7 +1,4 @@
 ---
-- name: Debugging
-  debug: msg="{{ ansible_distribution }} {{ ansible_os_family }} {{ ansible_distribution_version }} {{ ansible_distribution_release }} {{ ansible_distribution_major_version }} {{ ansible_lsb.major_release }}"
-
 - set_fact:
     os="{{ ansible_distribution }}_{{ ansible_distribution_major_version }}.0"
   when:

--- a/tasks/install_odl_via_deb_path.yml
+++ b/tasks/install_odl_via_deb_path.yml
@@ -3,5 +3,5 @@
 
 - name: Install ODL via Deb path
   apt:
-    deb: "/home/vagrant/opendaylight_5.0.0-1_all.deb"
+    deb: "{{ deb_path }}"
     state: present

--- a/tasks/install_odl_via_deb_path.yml
+++ b/tasks/install_odl_via_deb_path.yml
@@ -1,0 +1,7 @@
+---
+- include: add_jessie_backports.yml
+
+- name: Install ODL via Deb path
+  apt:
+    deb: "/home/vagrant/opendaylight_5.0.0-1_all.deb"
+    state: present

--- a/tasks/install_odl_via_deb_repo.yml
+++ b/tasks/install_odl_via_deb_repo.yml
@@ -1,0 +1,7 @@
+---
+- include: add_odl_deb_repo.yml
+
+- name: Install ODL via Deb repo
+  apt:
+    name=opendaylight
+    state=present

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -39,12 +39,19 @@ nb_rest_port: 8080
 # Valid options:
 #   rpm_repo: Install ODL using its Yum repo config
 #   rpm_path: Install ODL from a local path or remote URL
-install_method: "rpm_repo"
+#   dep_repo: Install ODL using a debian repository
+install_method: "deb_repo"
 
 # URL of the .repo config to use when installing ODL from a repo
 # NB: This will only take effect when `install_method` is "rpm_repo"
 rpm_repo_file: "opendaylight-5-release.repo"
 rpm_repo_url: "https://git.opendaylight.org/gerrit/gitweb?p=integration/packaging.git;a=blob_plain;f=rpm/example_repo_configs/opendaylight-5-release.repo;hb=refs/heads/master"
+
+# URL of the deb repository to use when installing ODL from a repo
+# NB: This will only take effect when `install_method` is "deb_repo"
+deb_repo_url: "deb http://download.opensuse.org/repositories/home:/akshitajha/{{ os }}/ /"
+# URL to add the repository key to 'apt'
+deb_key: "http://download.opensuse.org/repositories/home:akshitajha/{{ os }}/Release.key"
 
 # This will be passed as the `name` param to the Ansible `yum` module.
 # `name` param docs: "You can also pass a url or a local path to a rpm file."

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -40,7 +40,7 @@ nb_rest_port: 8080
 #   rpm_repo: Install ODL using its Yum repo config
 #   rpm_path: Install ODL from a local path or remote URL
 #   dep_repo: Install ODL using a debian repository
-install_method: "deb_repo"
+install_method: "rpm_repo"
 
 # URL of the .repo config to use when installing ODL from a repo
 # NB: This will only take effect when `install_method` is "rpm_repo"
@@ -60,3 +60,10 @@ deb_key: "http://download.opensuse.org/repositories/home:akshitajha/{{ os }}/Rel
 # NB: This will only take effect when `install_method` is "rpm_path"
 # Default to the Boron RPM hosted on the CentOS Community Build System
 rpm_path: "http://cbs.centos.org/repos/nfv7-opendaylight-5-release/x86_64/os/Packages/opendaylight-4.2.0-1.el7.noarch.rpm"
+
+# This will be passed as the `deb` param to the Ansible `apt` module.
+# `deb` param docs: "Path to a .deb package on the remote machine. If :// in the path,
+#                    ansible will attempt to download deb before installing."
+#   See: http://docs.ansible.com/ansible/apt_module.html
+# This is used when `install_method` is "deb_path"
+deb_path: "http://download.opensuse.org/repositories/home:/akshitajha/{{ os }}/all/opendaylight_5.0.0-1_all.deb"


### PR DESCRIPTION
This commit checks the OS and then branches for either RPM or Deb
installs. This patch allows ODL to be installed in a debian distribution
(Debian or Ubuntu) via a deb repo.

Ansible version: 2.2.0.0
Tested for Debian 8.0 and Ubuntu 16.04

Signed-off-by: Akshita Jha <zenith158@gmail.com>