### PR TITLE
Add carbon .deb support for ansible-opendaylight

### DIFF
--- a/tasks/add_jessie_backports.yml
+++ b/tasks/add_jessie_backports.yml
@@ -1,6 +1,0 @@
-- name: Add jessie-backports
-  apt_repository:
-    repo="deb http://httpredir.debian.org/debian jessie-backports main"
-    state=present
-    filename='jessie-backports'
-    update_cache=yes

--- a/tasks/add_odl_deb_repo.yml
+++ b/tasks/add_odl_deb_repo.yml
@@ -1,13 +1,5 @@
-- name: Add the repository key to apt
-  apt_key:
-    url={{ deb_key }}
-    state=present
-
 - name: Add ODL deb repo
   apt_repository:
-    repo={{ deb_repo_url }}
-    state=present
-    filename='opendaylight'
-    update_cache=yes
-
-- include: add_jessie_backports.yml
+    repo: "{{ deb_repo_url }}"
+    state: present
+    update_cache: yes

--- a/tasks/install_odl.yml
+++ b/tasks/install_odl.yml
@@ -4,25 +4,6 @@
 # Docs:
 # `ansible_os_family` param: Operating System family (Debian/RedHat)
 # `ansible_distribtion` param: Operating system (Debian/Ubuntu/CentOS etc.)
-# `ansible_distribution_version` param: The complete version of the OS
-# `ansible_distribution_major_version` param: The major version of the OS
-
-# The .debs are currently hosted in OpenSUSE Build Service (OBS).
-# In OBS, the name of the .deb repository for Debian contains the OS name
-# in the form Debian_{major_version} (eg: Debian_8.0).
-- name: Set OS name for .deb repo for Debian in OBS
-  set_fact:
-    os="{{ ansible_distribution }}_{{ ansible_distribution_major_version }}.0"
-  when:
-    ansible_distribution == "Debian"
-
-# In OBS, the name of the .deb repository for Ubuntu contains the OS name
-# in the form xUbuntu_{version} (eg: xUbuntu_16.04).
-- name: Set OS name for .deb repo for Ubuntu in OBS
-  set_fact:
-    os="x{{ ansible_distribution }}_{{ ansible_distribution_version }}"
-  when:
-    - ansible_distribution == "Ubuntu" and ansible_distribution_version == "16.04"
 
 # Install ODL .deb using debian repo
 - include: install_odl_via_deb_repo.yml

--- a/tasks/install_odl_via_deb_repo.yml
+++ b/tasks/install_odl_via_deb_repo.yml
@@ -3,5 +3,5 @@
 
 - name: Install ODL via Deb repo
   apt:
-    name=opendaylight
-    state=present
+    name: opendaylight
+    state: present

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -50,9 +50,7 @@ rpm_repo_url: "https://git.opendaylight.org/gerrit/gitweb?p=integration/packagin
 
 # URL of the deb repository to use when installing ODL from a repo
 # NB: This will only take effect when `install_method` is "deb_repo"
-deb_repo_url: "deb http://download.opensuse.org/repositories/home:/akshitajha/{{ os }}/ /"
-# URL to add the repository key to 'apt'
-deb_key: "http://download.opensuse.org/repositories/home:akshitajha/{{ os }}/Release.key"
+deb_repo_url: "ppa:odl-team/carbon"
 
 # This will be passed as the `name` param to the Ansible `yum` module.
 # `name` param docs: "You can also pass a url or a local path to a rpm file."
@@ -67,4 +65,4 @@ rpm_path: "http://cbs.centos.org/repos/nfv7-opendaylight-52-release/x86_64/os/Pa
 #                    ansible will attempt to download deb before installing."
 #   See: http://docs.ansible.com/ansible/apt_module.html
 # This is used when `install_method` is "deb_path"
-deb_path: "http://download.opensuse.org/repositories/home:/akshitajha/{{ os }}/all/opendaylight_5.0.0-1_all.deb"
+deb_path: ""


### PR DESCRIPTION
Ansible-opendaylight made use of OpenSUSE Build Service (OBS) to
install .deb packages. This patch removes support for OBS and
instead adds carbon .deb support for Ubuntu 16.04 using Launchpad
PPA, `ppa:odl-team/carbon`.

This patch temporarily removes support for Debian OS.

Signed-off-by: Akshita Jha <zenith158@gmail.com>